### PR TITLE
default `$callable` for filter is `identity`

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ $collection->extract('*.b')->toArray(); //[1, 2, 3]
 toArray(extract([['a' => ['b' => 1]], ['a' => ['b' => 2]]], 'a.b')); //[1, 2]
 ```
 
-#### filter(callable $function) : Collection
+#### filter(callable $function = null) : Collection
 Returns a lazy collection of items for which $function(value, key) returned true.
 ```php
 Collection::from([1, 3, 3, 2])
@@ -498,6 +498,17 @@ Collection::from([1, 3, 3, 2])
 ```php
 toArray(values(filter([1, 3, 3, 2], function ($value) {return $value > 2;}))); //[3, 3]
 ```
+
+If `$function` is not provided, `\DusanKasan\Knapsack\identity` is used so every falsy value is removed. 
+```php
+Collection::from([0, 0.0, false, null, "", []])
+    ->filter()
+    ->isEmpty() //true
+```
+```php
+isEmpty(values(filter([0, 0.0, false, null, "", []]))); //true
+```
+
 
 #### find(callable $function, mixed $ifNotFound = null, bool $convertToCollection = false) : mixed|Collection
 Returns first value for which $function(value, key) returns true. If no item is matched, returns $ifNotFound. If $convertToCollection is true and the return value is a collection (array|Traversable) an instance of Collection will be returned.

--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -19,10 +19,10 @@ trait CollectionTrait
     /**
      * Returns a lazy collection of items for which $function returned true.
      *
-     * @param callable $function ($value, $key)
+     * @param callable|null $function ($value, $key)
      * @return Collection
      */
-    public function filter(callable $function)
+    public function filter(callable $function = null)
     {
         return filter($this->getItems(), $function);
     }

--- a/src/collection_functions.php
+++ b/src/collection_functions.php
@@ -244,11 +244,17 @@ function map($collection, callable $function)
  * Returns a lazy collection of items from $collection for which $function returns true.
  *
  * @param array|Traversable $collection
- * @param callable $function ($value, $key)
+ * @param callable|null $function ($value, $key)
  * @return Collection
  */
-function filter($collection, callable $function)
+function filter($collection, callable $function = null)
 {
+    if (null === $function) {
+        $function = function ($value) {
+            return (bool)$value;
+        };
+    };
+
     $generatorFactory = function () use ($collection, $function) {
         foreach ($collection as $key => $value) {
             if ($function($value, $key)) {

--- a/tests/spec/CollectionSpec.php
+++ b/tests/spec/CollectionSpec.php
@@ -110,6 +110,14 @@ class CollectionSpec extends ObjectBehavior
             ->shouldReturn([3 => 2]);
     }
 
+    function it_can_filter_falsy_values()
+    {
+        $this->beConstructedWith([false, null, '', 0, 0.0, []]);
+
+        $this->filter()->isEmpty()->shouldReturn(true);
+
+    }
+
     function it_can_distinct()
     {
         $this->beConstructedWith([1, 3, 3, 2,]);


### PR DESCRIPTION
How about a default `$callable` value for filter to just remove "falsy" values?
