### PR TITLE
Build the arrays first directly and return them as Collections

### DIFF
--- a/src/collection_functions.php
+++ b/src/collection_functions.php
@@ -409,11 +409,13 @@ function groupBy($collection, callable $function)
     foreach ($collection as $key => $value) {
         $newKey = $function($value, $key);
 
-        $group = isset($result[$newKey]) ? $result[$newKey] : new Collection([]);
-        $result[$newKey] = $group->append($value);
+        $result[$newKey][] = $value;
     }
 
-    return Collection::from($result);
+    return Collection::from($result)
+        ->map(function ($entry) {
+            return new Collection($entry);
+        });
 }
 
 /**


### PR DESCRIPTION
This will prevent creating a huge callstack when grouping Collections
with lots of entries resolving to the same group, fixing #25 

Tests pass and no BC breaks as we rebuild the results to Collections.