### PR TITLE
Improve performance dramatically

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -3,7 +3,6 @@
 namespace DusanKasan\Knapsack;
 
 use DusanKasan\Knapsack\Exceptions\InvalidArgument;
-use Iterator;
 use IteratorAggregate;
 use RecursiveArrayIterator;
 use Traversable;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -2,19 +2,18 @@
 
 namespace DusanKasan\Knapsack;
 
-use Closure;
 use DusanKasan\Knapsack\Exceptions\InvalidArgument;
 use Iterator;
 use IteratorAggregate;
 use RecursiveArrayIterator;
 use Traversable;
 
-class Collection implements Iterator, \Serializable
+class Collection implements IteratorAggregate, \Serializable
 {
     use CollectionTrait;
 
     /**
-     * @var Iterator
+     * @var Traversable
      */
     protected $input;
 
@@ -24,7 +23,7 @@ class Collection implements Iterator, \Serializable
     private $inputFactory;
 
     /**
-     * @param callable|Closure|array|Traversable $input If callable is passed, it must return an array|Traversable.
+     * @param callable|array|Traversable $input If callable is passed, it must return an array|Traversable.
      */
     public function __construct($input)
     {
@@ -32,12 +31,8 @@ class Collection implements Iterator, \Serializable
             $this->inputFactory = $input;
             $this->input = $input();
         } elseif (is_array($input)) {
-            $input = new RecursiveArrayIterator($input);
-            $this->input = $input;
-        } elseif ($input instanceof IteratorAggregate) {
-            $input = $input->getIterator();
-            $this->input = $input;
-        } elseif ($input instanceof Iterator) {
+            $this->input = new RecursiveArrayIterator($input);
+        } elseif ($input instanceof Traversable) {
             $this->input = $input;
         } else {
             throw new InvalidArgument;
@@ -47,7 +42,7 @@ class Collection implements Iterator, \Serializable
     /**
      * Static alias of normal constructor.
      *
-     * @param array|Traversable $input
+     * @param callable|array|Traversable $input
      * @return Collection
      */
     public static function from($input)
@@ -95,47 +90,15 @@ class Collection implements Iterator, \Serializable
     }
 
     /**
-     * @inheritdoc
-     */
-    public function current()
-    {
-        return $this->input->current();
-    }
-
-    /**
      * {@inheritdoc}
      */
-    public function next()
-    {
-        $this->input->next();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function key()
-    {
-        return $this->input->key();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function valid()
-    {
-        return $this->input->valid();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function rewind()
+    public function getIterator()
     {
         if ($this->inputFactory) {
             $this->input = call_user_func($this->inputFactory);
         }
 
-        $this->input->rewind();
+        return $this->input;
     }
 
     /**

--- a/src/collection_functions.php
+++ b/src/collection_functions.php
@@ -1214,11 +1214,11 @@ function second($collection)
 function combine($keys, $values)
 {
     $generatorFactory = function () use ($keys, $values) {
-        $keyIt = new IteratorIterator(new Collection($keys));
+        $keyCollection = new Collection($keys);
         $valueIt = new IteratorIterator(new Collection($values));
         $valueIt->rewind();
 
-        foreach ($keyIt as $key) {
+        foreach ($keyCollection as $key) {
             if (!$valueIt->valid()) {
                 break;
             }
@@ -1356,12 +1356,15 @@ function has($collection, $key)
  */
 function zip(...$collections)
 {
-    $iterators = [];
-    foreach ($collections as $collection) {
-        $iterator = new IteratorIterator(new Collection($collection));
-        $iterator->rewind();
-        $iterators[] = $iterator;
-    }
+    /* @var Iterator[] $iterators */
+    $iterators = array_map(
+        function ($collection) {
+            $it = new IteratorIterator(new Collection($collection));
+            $it->rewind();
+            return $it;
+        },
+        $collections
+    );
 
     $generatorFactory = function () use ($iterators) {
         while (true) {

--- a/src/collection_functions.php
+++ b/src/collection_functions.php
@@ -5,6 +5,8 @@ namespace DusanKasan\Knapsack;
 use DusanKasan\Knapsack\Exceptions\InvalidArgument;
 use DusanKasan\Knapsack\Exceptions\ItemNotFound;
 use DusanKasan\Knapsack\Exceptions\NoMoreItems;
+use Iterator;
+use IteratorIterator;
 use Traversable;
 
 /**
@@ -751,10 +753,10 @@ function interpose($collection, $separator)
 function interleave(...$collections)
 {
     $generatorFactory = function () use ($collections) {
-        /* @var \Iterator[] $iterators */
+        /* @var Iterator[] $iterators */
         $iterators = array_map(
             function ($collection) {
-                $it = new \IteratorIterator(new Collection($collection));
+                $it = new IteratorIterator(new Collection($collection));
                 $it->rewind();
                 return $it;
             },
@@ -1212,8 +1214,8 @@ function second($collection)
 function combine($keys, $values)
 {
     $generatorFactory = function () use ($keys, $values) {
-        $keyIt = new \IteratorIterator(new Collection($keys));
-        $valueIt = new \IteratorIterator(new Collection($values));
+        $keyIt = new IteratorIterator(new Collection($keys));
+        $valueIt = new IteratorIterator(new Collection($values));
         $valueIt->rewind();
 
         foreach ($keyIt as $key) {
@@ -1356,7 +1358,7 @@ function zip(...$collections)
 {
     $iterators = [];
     foreach ($collections as $collection) {
-        $iterator = new \IteratorIterator(new Collection($collection));
+        $iterator = new IteratorIterator(new Collection($collection));
         $iterator->rewind();
         $iterators[] = $iterator;
     }

--- a/tests/spec/CollectionSpec.php
+++ b/tests/spec/CollectionSpec.php
@@ -10,11 +10,10 @@ use DusanKasan\Knapsack\Exceptions\InvalidReturnValue;
 use DusanKasan\Knapsack\Exceptions\ItemNotFound;
 use DusanKasan\Knapsack\Exceptions\NoMoreItems;
 use DusanKasan\Knapsack\Tests\Helpers\PlusOneAdder;
-use function DusanKasan\Knapsack\reverse;
-use Iterator;
 use IteratorAggregate;
 use PhpSpec\ObjectBehavior;
 use Serializable;
+use Traversable;
 
 /**
  * @mixin Collection
@@ -25,8 +24,8 @@ class CollectionSpec extends ObjectBehavior
     {
         $this->beConstructedWith([1, 2, 3]);
         $this->shouldHaveType(Collection::class);
-        $this->shouldHaveType(\Traversable::class);
-        $this->shouldHaveType(\Serializable::class);
+        $this->shouldHaveType(Traversable::class);
+        $this->shouldHaveType(Serializable::class);
     }
 
     function it_can_be_instantiated_from_iterator()

--- a/tests/spec/CollectionSpec.php
+++ b/tests/spec/CollectionSpec.php
@@ -25,7 +25,8 @@ class CollectionSpec extends ObjectBehavior
     {
         $this->beConstructedWith([1, 2, 3]);
         $this->shouldHaveType(Collection::class);
-        $this->shouldHaveType(Iterator::class);
+        $this->shouldHaveType(\Traversable::class);
+        $this->shouldHaveType(\Serializable::class);
     }
 
     function it_can_be_instantiated_from_iterator()
@@ -465,26 +466,16 @@ class CollectionSpec extends ObjectBehavior
     {
         $this->beConstructedWith([1, 3, 3, 2,]);
 
-        $collection = $this->reverse();
-
-        $collection->rewind();
-        $collection->valid()->shouldReturn(true);
-        $collection->key()->shouldReturn(3);
-        $collection->current()->shouldReturn(2);
-        $collection->next();
-        $collection->valid()->shouldReturn(true);
-        $collection->key()->shouldReturn(2);
-        $collection->current()->shouldReturn(3);
-        $collection->next();
-        $collection->valid()->shouldReturn(true);
-        $collection->key()->shouldReturn(1);
-        $collection->current()->shouldReturn(3);
-        $collection->next();
-        $collection->valid()->shouldReturn(true);
-        $collection->key()->shouldReturn(0);
-        $collection->current()->shouldReturn(1);
-        $collection->next();
-        $collection->valid()->shouldReturn(false);
+        $this
+            ->reverse()
+            ->toArray()
+            ->shouldReturn([
+                3 => 2,
+                2 => 3,
+                1 => 3,
+                0 => 1,
+            ])
+        ;
     }
 
     function it_can_reduce_from_right()


### PR DESCRIPTION
Hi, thanks for releasing this great library! I prefer this rather than [nikic/iter](https://github.com/nikic/iter) because this takes the OOP-like approach.
However there's some points losing to iter in performance, so I want to improve that.

Please see the following simple snippet comparing two libs performance:
 
```php
$filterFn = function () { return true; };
$mapFn    = function ($v) { return $v; };

$sampleCollection = array_fill(0, 1000000, 'x');

$st = microtime(true);
iterator_to_array(
    \iter\map(
        $mapFn,
        \iter\filter(
            $filterFn,
            $sampleCollection
        )
    )
);
echo sprintf('iter: %.6f sec', microtime(true) - $st), "\n";

$st = microtime(true);
iterator_to_array(
    \DusanKasan\Knapsack\Collection::from($sampleCollection)
        ->filter($filterFn)
        ->map($mapFn)
);
echo sprintf('Knapsack: %.6f sec', microtime(true) - $st), "\n";
```

**note**: Both of them take the same approach, which is generating the lazy-collection that computes on operations of traversing.

In my results:

```
iter: 5.947058 sec
Knapsack: 36.837850 sec
```

As you can see, the difference is so huge, Knapsack is explicitly slow compared with iter.
 
## What's problem

`Knapsack\Collection` implements `Iterator` but iter doesn't. 
So, it seems to be caused to lead bad performance impact, and my patch on this PR exactly focuses on that - `Iterator` is only used when the logic really needs (e.g. interleave). 

In fact, the result ends up like following after my patch is applied:

```
iter: 5.480360 sec
Knapsack: 5.591903 sec
```

Besides, the performance check you provide achieves the good result than before:

before:

```
$ php tests/performance/map_vs_array_map.php
+------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
| operation details                                                                  | native execution time | collection execution time | difference (percent) |
+------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
| array_map vs Collection::map on 10000 integers (addition)                          | 0.014703154563904s    | 0.18897454738617s         | 1285%                |
| array_map vs Collection::map on 10000 strings (concatenation)                      | 0.021801376342773s    | 0.25404767990112s         | 1165%                |
| array_map vs Collection::map on 10000 objects (object to field value)              | 0.017388963699341s    | 0.20323369503021s         | 1168%                |
| array_map vs Collection::map on 10000 md5 invocations                              | 0.029221034049988s    | 0.20992181301117s         | 718%                 |
| array_map vs Collection::map on 10000 integers n, counting sum(0, n) the naive way | 9.6942321062088s      | 9.6334856987s             | 99%                  |
+------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+

$ php tests/performance/reduce_vs_array_reduce.php
+-------------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
| operation details                                                                         | native execution time | collection execution time | difference (percent) |
+-------------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
| array_reduce vs Collection::reduce on 10000 integers (addition)                           | 0.025390815734863s    | 0.16423649787903s         | 646%                 |
| array_reduce vs Collection::reduce on 10000 strings (concatenation)                       | 0.034023523330688s    | 0.13736398220062s         | 403%                 |
| array_reduce vs Collection::reduce on 10000 object (object to field value)                | 0.018415665626526s    | 0.12140438556671s         | 659%                 |
| array_reduce vs Collection::reduce on 10000 md5 invocations                               | 0.030937099456787s    | 0.12602620124817s         | 407%                 |
| array_reduce vs Collection::reduce for 10000 integers n, counting sum(0, n) the naive way | 9.942040514946s       | 9.839556646347s           | 98%                  |
+-------------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
```

after:

```
$ php tests/performance/map_vs_array_map.php
+------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
| operation details                                                                  | native execution time | collection execution time | difference (percent) |
+------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
| array_map vs Collection::map on 10000 integers (addition)                          | 0.014729452133179s    | 0.027163410186768s        | 184%                 |
| array_map vs Collection::map on 10000 strings (concatenation)                      | 0.015099954605103s    | 0.028594446182251s        | 189%                 |
| array_map vs Collection::map on 10000 objects (object to field value)              | 0.017368984222412s    | 0.029714369773865s        | 171%                 |
| array_map vs Collection::map on 10000 md5 invocations                              | 0.027954363822937s    | 0.040060210227966s        | 143%                 |
| array_map vs Collection::map on 10000 integers n, counting sum(0, n) the naive way | 9.7906902074814s      | 10.129155540466s          | 103%                 |
+------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+

$ php tests/performance/reduce_vs_array_reduce.php
+-------------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
| operation details                                                                         | native execution time | collection execution time | difference (percent) |
+-------------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
| array_reduce vs Collection::reduce on 10000 integers (addition)                           | 0.014452695846558s    | 0.02052640914917s         | 142%                 |
| array_reduce vs Collection::reduce on 10000 strings (concatenation)                       | 0.032758975028992s    | 0.039231991767883s        | 119%                 |
| array_reduce vs Collection::reduce on 10000 object (object to field value)                | 0.016609573364258s    | 0.022549653053284s        | 135%                 |
| array_reduce vs Collection::reduce on 10000 md5 invocations                               | 0.028601837158203s    | 0.034251570701599s        | 119%                 |
| array_reduce vs Collection::reduce for 10000 integers n, counting sum(0, n) the naive way | 9.5106759309769s      | 9.3758726358414s          | 98%                  |
+-------------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
```

## BC Break

This change slightly makes a BC break - Collection can't call methods defined at Iterator anymore, but it's a little thing. Not much impact I think.

The replacing like following may help to work as in the previous:

before:

```php
$collection = Collection::from([1, 2, 3]);
$collection->rewind();
$collection->key();
$collection->current();
// ...
```

after:

```php
$it = new \IteratorIterator(Collecton::from([1, 2, 3]));
$it->rewind();
$it->key();
$it->current();
// ...
```

Thanks!