### PR TITLE
toArray() improvement

### DIFF
--- a/src/CollectionTrait.php
+++ b/src/CollectionTrait.php
@@ -879,8 +879,6 @@ trait CollectionTrait
         return replaceByKeys($this->getItems(), $replacementMap);
     }
 
-
-
     /**
      * /**
      * Dumps this collection into array (recursively).

--- a/src/collection_functions.php
+++ b/src/collection_functions.php
@@ -17,12 +17,7 @@ use Traversable;
  */
 function toArray($collection)
 {
-    $arr = [];
-    foreach ($collection as $key => $value) {
-        $arr[$key] = $value;
-    }
-
-    return $arr;
+    return is_array($collection) ? $collection : iterator_to_array($collection);
 }
 
 /**

--- a/tests/spec/CollectionSpec.php
+++ b/tests/spec/CollectionSpec.php
@@ -91,6 +91,34 @@ class CollectionSpec extends ObjectBehavior
         $this->take(2)->toArray()->shouldReturn([1, 1]);
     }
 
+    function it_can_convert_to_array()
+    {
+        $iterator = new \ArrayIterator([
+            'foo',
+        ]);
+
+        $this->beConstructedWith(function () use ($iterator) {
+            yield 'no key';
+            yield 'with key' => 'this value is overwritten by the same key';
+            yield 'nested' => [
+                'y' => 'z',
+            ];
+            yield 'iterator is not converted' => $iterator;
+            yield 'with key' => 'x';
+        });
+
+        $this
+            ->toArray()
+            ->shouldReturn([
+                'no key',
+                'with key' => 'x',
+                'nested' => [
+                    'y' => 'z',
+                ],
+                'iterator is not converted' => $iterator,
+            ]);
+    }
+
     function it_can_filter()
     {
         $this->beConstructedWith([1, 3, 3, 2,]);

--- a/tests/spec/CollectionSpec.php
+++ b/tests/spec/CollectionSpec.php
@@ -115,7 +115,6 @@ class CollectionSpec extends ObjectBehavior
         $this->beConstructedWith([false, null, '', 0, 0.0, []]);
 
         $this->filter()->isEmpty()->shouldReturn(true);
-
     }
 
     function it_can_distinct()


### PR DESCRIPTION
This PR changes `toArray()` logic using built-in `iterator_to_array` function.
Bringing a little performance improvement without changing behavior against previous version.

This time, I simply tested with following snippet:

```php
<?php require __DIR__ . '/vendor/autoload.php';

define('ITEMS_COUNT', 100000);
define('TRY_COUNT', 100);

$grandchildren = array_fill(0, ITEMS_COUNT, 'grand child');
$grandchildren[] = array_fill(0, ITEMS_COUNT, 'great grandchild');

// with Array

$array = array_fill(0, ITEMS_COUNT, 'x');
$array[] = $grandchildren;
$coll = \DusanKasan\Knapsack\Collection::from($array);

$st = microtime(true);
for ($i = 0; $i < TRY_COUNT; $i++) $coll->toArray();
printf("with array -> AVG: %.6f [s]\n", (microtime(true) - $st) / TRY_COUNT);

// with Generator

$generator = function () use ($grandchildren) {
    for ($i = 0; $i < ITEMS_COUNT; $i++) {
        yield 'x';
    }
    yield $grandchildren;
};
$coll = \DusanKasan\Knapsack\Collection::from($generator);

$st = microtime(true);
for ($i = 0; $i < TRY_COUNT; $i++) $coll->toArray();
printf("with Generator -> AVG: %.6f [s]\n", (microtime(true) - $st) / TRY_COUNT);

// show memory usage

printf("Peak Memory Usage : %.3f [MB]\n", memory_get_peak_usage() / (1024 * 1024));
```

**before**

```
with array -> AVG: 0.022309 [s]
with Generator -> AVG: 0.202728 [s]
Peak Memory Usage : 21.252 [MB]
```

**after**

```
with array -> AVG: 0.008613 [s]
with Generator -> AVG: 0.174608 [s]
Peak Memory Usage : 21.252 [MB]
```

For generator is not very improved but for array is 2x+ faster.
