### PR TITLE
Ensure that input factory returns array or Traversable when created from a callable

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -3,6 +3,7 @@
 namespace DusanKasan\Knapsack;
 
 use DusanKasan\Knapsack\Exceptions\InvalidArgument;
+use DusanKasan\Knapsack\Exceptions\InvalidReturnValue;
 use IteratorAggregate;
 use RecursiveArrayIterator;
 use Traversable;
@@ -36,7 +37,7 @@ class Collection implements IteratorAggregate, \Serializable
         } elseif ($input instanceof Traversable) {
             $this->input = $input;
         } else {
-            throw new InvalidArgument;
+            throw $this->inputFactory ? new InvalidReturnValue : new InvalidArgument;
         }
     }
 
@@ -92,6 +93,7 @@ class Collection implements IteratorAggregate, \Serializable
 
     /**
      * {@inheritdoc}
+     * @throws InvalidReturnValue
      */
     public function getIterator()
     {
@@ -100,6 +102,10 @@ class Collection implements IteratorAggregate, \Serializable
 
             if (is_array($input)) {
                 $input = new RecursiveArrayIterator($input);
+            }
+
+            if (!($input instanceof Traversable)) {
+                throw new InvalidReturnValue;
             }
 
             $this->input = $input;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -28,8 +28,10 @@ class Collection implements IteratorAggregate, \Serializable
     {
         if (is_callable($input)) {
             $this->inputFactory = $input;
-            $this->input = $input();
-        } elseif (is_array($input)) {
+            $input = $input();
+        }
+
+        if (is_array($input)) {
             $this->input = new RecursiveArrayIterator($input);
         } elseif ($input instanceof Traversable) {
             $this->input = $input;
@@ -94,7 +96,13 @@ class Collection implements IteratorAggregate, \Serializable
     public function getIterator()
     {
         if ($this->inputFactory) {
-            $this->input = call_user_func($this->inputFactory);
+            $input = call_user_func($this->inputFactory);
+
+            if (is_array($input)) {
+                $input = new RecursiveArrayIterator($input);
+            }
+
+            $this->input = $input;
         }
 
         return $this->input;

--- a/tests/spec/CollectionSpec.php
+++ b/tests/spec/CollectionSpec.php
@@ -80,7 +80,7 @@ class CollectionSpec extends ObjectBehavior
     function it_will_throw_when_passed_callable_will_return_something_other_than_array_or_traversable()
     {
         $this->beConstructedWith(function () { return 1; });
-        $this->shouldThrow(InvalidArgument::class)->duringInstantiation();
+        $this->shouldThrow(InvalidReturnValue::class)->duringInstantiation();
     }
 
     function it_can_be_created_statically()

--- a/tests/spec/CollectionSpec.php
+++ b/tests/spec/CollectionSpec.php
@@ -55,6 +55,34 @@ class CollectionSpec extends ObjectBehavior
         $this->shouldThrow(InvalidArgument::class)->duringInstantiation();
     }
 
+    function it_can_be_instantiated_from_callable_returning_an_array()
+    {
+        $this->beConstructedWith(function () { return [1, 2, 3]; });
+        $this->toArray()->shouldReturn([1, 2, 3]);
+    }
+
+    function it_can_be_instantiated_from_callable_returning_an_iterator()
+    {
+        $this->beConstructedWith(function () { return new ArrayIterator([1, 2, 3]); });
+        $this->toArray()->shouldReturn([1, 2, 3]);
+    }
+
+    function it_can_be_instantiated_from_callable_returning_a_generator()
+    {
+        $this->beConstructedWith(function () {
+            foreach ([1, 2, 3] as $value) {
+                yield $value;
+            }
+        });
+        $this->toArray()->shouldReturn([1, 2, 3]);
+    }
+
+    function it_will_throw_when_passed_callable_will_return_something_other_than_array_or_traversable()
+    {
+        $this->beConstructedWith(function () { return 1; });
+        $this->shouldThrow(InvalidArgument::class)->duringInstantiation();
+    }
+
     function it_can_be_created_statically()
     {
         $this->beConstructedThrough('from', [[1, 2]]);


### PR DESCRIPTION
The return value from the input factory was not checked when the Collection is created from a callable. 
As only arrays and Traversables are valid return types, this should be checked.

Also `IteratorAggregate::getIterator()` must return a `Traversable` so we need to wrap the return value of the input factory in an `ArrayIterator` in case it is an array.