### PR TITLE
Use ArrayIterator instead of RecursiveArrayIterator for array input

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -2,10 +2,10 @@
 
 namespace DusanKasan\Knapsack;
 
+use ArrayIterator;
 use DusanKasan\Knapsack\Exceptions\InvalidArgument;
 use DusanKasan\Knapsack\Exceptions\InvalidReturnValue;
 use IteratorAggregate;
-use RecursiveArrayIterator;
 use Traversable;
 
 class Collection implements IteratorAggregate, \Serializable
@@ -33,7 +33,7 @@ class Collection implements IteratorAggregate, \Serializable
         }
 
         if (is_array($input)) {
-            $this->input = new RecursiveArrayIterator($input);
+            $this->input = new ArrayIterator($input);
         } elseif ($input instanceof Traversable) {
             $this->input = $input;
         } else {
@@ -101,7 +101,7 @@ class Collection implements IteratorAggregate, \Serializable
             $input = call_user_func($this->inputFactory);
 
             if (is_array($input)) {
-                $input = new RecursiveArrayIterator($input);
+                $input = new ArrayIterator($input);
             }
 
             if (!($input instanceof Traversable)) {


### PR DESCRIPTION
This PR is regarding my comment in https://github.com/DusanKasan/Knapsack/pull/36#discussion_r112868241.

I don't see a value in using an `RecursiveArrayIterator` instead of a simple `ArrayIterator` for `array` input: We don't use the additional `{get|has}Children()` methods and don't use it in combination with a `RecursiveIteratorIterator` for flat iteration over a multi-dimensional array. 
Thus I think it's safe to replace it. The tests pass and performance seems to be roughly the same (the timings differ a bit if I run the performance script multiple time on my pc so I'm not sure what the exact difference is; maybe you have a more reliable way to test this?).