### PR TITLE
Fix `@param` annotation of `reduce()`

### DIFF
--- a/src/collection_functions.php
+++ b/src/collection_functions.php
@@ -289,7 +289,7 @@ function concat(...$collections)
  * next iteration. The output of $function on last element is the return value of this function.
  *
  * @param array|Traversable $collection
- * @param callable $function ($value, $key)
+ * @param callable $function ($tmpValue, $value, $key)
  * @param mixed $startValue
  * @return mixed
  */


### PR DESCRIPTION
The first parameter of the callable `$function` of `reduce()` is the resulting item.