### PR TITLE
Improve performance on distinct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ coverage.clover
 coverage.xml
 
 phpunit.xml
+
+.idea

--- a/src/collection_functions.php
+++ b/src/collection_functions.php
@@ -32,8 +32,8 @@ function distinct($collection)
         $distinctValues = [];
 
         foreach ($collection as $key => $value) {
-            if (!in_array($value, $distinctValues)) {
-                $distinctValues[] = $value;
+            if (!isset($distinctValues[$value])) {
+                $distinctValues[$value] = true;
                 yield $key => $value;
             }
         }

--- a/tests/performance/distinct_vs_array_unique.php
+++ b/tests/performance/distinct_vs_array_unique.php
@@ -1,0 +1,181 @@
+<?php
+
+use DusanKasan\Knapsack\Collection;
+use Symfony\Component\Console\Helper\Table;
+
+include_once __DIR__ . "/../../vendor/autoload.php";
+
+const NUMBER_OF_ITEMS = 10000;
+const REPEAT_COUNT = 10;
+
+function getIntegerReport()
+{
+    $arrayMapDeltas = 0.0;
+    $collectionMapDeltas = 0.0;
+    $fixtureProvider = function () {
+        $array = [];
+        for ($i = 0; $i < NUMBER_OF_ITEMS; $i++) {
+            $array[] = $i;
+        }
+
+        return $array;
+    };
+    $mapper = function ($temp, $item) {
+        return $item + $temp;
+    };
+
+    for ($j = 0; $j < REPEAT_COUNT; $j++) {
+        $array = $fixtureProvider();
+
+
+        $arrayMapStart = microtime(true);
+        array_unique($array);
+        $arrayMapDeltas += microtime(true) - $arrayMapStart;
+
+        $collection = new Collection($array);
+        $collectionMapStart = microtime(true);
+        $collection->distinct()->realize();
+        $collectionMapDeltas += microtime(true) - $collectionMapStart;
+    }
+
+    return [
+        'name' => 'array_unique vs Collection::distinct on ' . NUMBER_OF_ITEMS . ' integers (addition)',
+        'native' => (float) $arrayMapDeltas / REPEAT_COUNT,
+        'collection' => (float) $collectionMapDeltas / REPEAT_COUNT
+    ];
+}
+
+function getStringReport()
+{
+    $arrayMapDeltas = 0.0;
+    $collectionMapDeltas = 0.0;
+    $fixtureProvider = function () {
+        $array = [];
+        for ($i = 0; $i < NUMBER_OF_ITEMS; $i++) {
+            $array[] = $i . 'asd';
+        }
+
+        return $array;
+    };
+    $mapper = function ($temp, $item) {
+        return $temp . $item;
+    };
+
+    for ($j = 0; $j < REPEAT_COUNT; $j++) {
+        $array = $fixtureProvider();
+        $arrayMapStart = microtime(true);
+        array_unique($array);
+        $arrayMapDeltas += microtime(true) - $arrayMapStart;
+
+        $array = $fixtureProvider();
+        $collection = new Collection($array);
+        $collectionMapStart = microtime(true);
+        $collection->distinct()->realize();
+        $collectionMapDeltas += microtime(true) - $collectionMapStart;
+    }
+
+    return [
+        'name' => 'array_unique vs Collection::distinct on ' . NUMBER_OF_ITEMS . ' strings (concatenation)',
+        'native' => (float) $arrayMapDeltas / REPEAT_COUNT,
+        'collection' => (float) $collectionMapDeltas / REPEAT_COUNT
+    ];
+}
+
+function getComplexOperationReport()
+{
+    $arrayMapDeltas = 0.0;
+    $collectionMapDeltas = 0.0;
+    $fixtureProvider = function () {
+        $array = [];
+        for ($i = 0; $i < NUMBER_OF_ITEMS; $i++) {
+            $array[] = $i;
+        }
+
+        return $array;
+    };
+    $mapper = function ($temp, $item) {
+        $result = 0;
+        for (; $item > 0; $item--) {
+            $result += $item;
+        }
+
+        return $temp + $result;
+    };
+
+    for ($j = 0; $j < REPEAT_COUNT; $j++) {
+        $array = $fixtureProvider();
+        $arrayMapStart = microtime(true);
+        array_unique($array);
+        $arrayMapDeltas += microtime(true) - $arrayMapStart;
+
+        $array = $fixtureProvider();
+        $collection = new Collection($array);
+        $collectionMapStart = microtime(true);
+        $collection->distinct()->realize();
+        $collectionMapDeltas += microtime(true) - $collectionMapStart;
+    }
+
+    return [
+        'name' => 'array_unique vs Collection::distinct for ' . NUMBER_OF_ITEMS . ' integers n, counting sum(0, n) the naive way',
+        'native' => (float) $arrayMapDeltas / REPEAT_COUNT,
+        'collection' => (float) $collectionMapDeltas / REPEAT_COUNT
+    ];
+}
+
+function getHashReport()
+{
+    $arrayMapDeltas = 0.0;
+    $collectionMapDeltas = 0.0;
+    $fixtureProvider = function () {
+        $array = [];
+        for ($i = 0; $i < NUMBER_OF_ITEMS; $i++) {
+            $array[] = $i . 'asdf';
+        }
+
+        return $array;
+    };
+    $mapper = function ($temp, $item) {
+        return md5($temp . $item);
+    };
+
+    for ($j = 0; $j < REPEAT_COUNT; $j++) {
+        $array = $fixtureProvider();
+        $arrayMapStart = microtime(true);
+        array_unique($array);
+        $arrayMapDeltas += microtime(true) - $arrayMapStart;
+
+        $array = $fixtureProvider();
+        $collection = new Collection($array);
+        $collectionMapStart = microtime(true);
+        $collection->distinct()->realize();
+        $collectionMapDeltas += microtime(true) - $collectionMapStart;
+    }
+
+    return [
+        'name' => 'array_unique vs Collection::distinct on ' . NUMBER_OF_ITEMS . ' md5 invocations',
+        'native' => (float) $arrayMapDeltas / REPEAT_COUNT,
+        'collection' => (float) $collectionMapDeltas / REPEAT_COUNT
+    ];
+}
+
+function addReportToTable(Table $table, $reportData)
+{
+    $row = [
+        $reportData['name'],
+        $reportData['native'] . 's',
+        $reportData['collection'] . 's',
+        ((int) (($reportData['collection'] / $reportData['native']) * 100)) . '%',
+    ];
+
+    $table->addRow($row);
+}
+
+$table = new Table(new Symfony\Component\Console\Output\ConsoleOutput());
+$table->setHeaders(['operation details', 'native execution time', 'collection execution time', 'difference (percent)']);
+
+addReportToTable($table, getIntegerReport());
+addReportToTable($table, getStringReport());
+addReportToTable($table, getHashReport());
+addReportToTable($table, getComplexOperationReport());
+
+$table->render();


### PR DESCRIPTION
The difference in performance on `distinct` vs `array_unique` is so large that we've decided to refactor some of our code to use the latter instead.

I wanted to see if I could improve the performance on `distinct`. I copied a one of the benchmarks in `tests/performance` and modified it to compare `distinct` vs `array_unique` instead. 

I ran the benchmark using the current solution and got this result:

```
+-------------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
| operation details                                                                         | native execution time | collection execution time | difference (percent) |
+-------------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
| array_unique vs Collection::distinct on 10000 integers (addition)                           | 0.00062398910522461s  | 0.17144465446472s         | 27475%             |
| array_unique vs Collection::distinct on 10000 strings (concatenation)                       | 0.00031847953796387s  | 1.1402836799622s          | 358039%            |
| array_unique vs Collection::distinct on 10000 md5 invocations                               | 0.00044071674346924s  | 1.3995371103287s          | 317559%            |
| array_unique vs Collection::distinct for 10000 integers n, counting sum(0, n) the naive way | 0.00051562786102295s  | 0.14881670475006s         | 28861%             |
+-------------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
```

I then changed the `distinct` implementation. I don't know anything about the underlying implementation of `array` or `in_array` in PHP, I just know PHP arrays are also key/value maps. Key/value maps tend to have very fast lookup in programming languages.  [According to this](https://stackoverflow.com/questions/2473989/list-of-big-o-for-php-functions) then `in_array` have a time complexity of `O(n)` while `isset` have a time complexity of "close to `O(1)`". By switching to `isset` we'll get a huge time complexity improvement.

I ran the benchmark again and got this result:

```
+---------------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
| operation details                                                                           | native execution time | collection execution time | difference (percent) |
+---------------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
| array_unique vs Collection::distinct on 10000 integers (addition)                           | 0.00050990581512451s  | 0.050813627243042s        | 9965%                |
| array_unique vs Collection::distinct on 10000 strings (concatenation)                       | 0.00026485919952393s  | 0.050021052360535s        | 18885%               |
| array_unique vs Collection::distinct on 10000 md5 invocations                               | 0.00030789375305176s  | 0.053486967086792s        | 17371%               |
| array_unique vs Collection::distinct for 10000 integers n, counting sum(0, n) the naive way | 0.00073227882385254s  | 0.065831804275513s        | 8989%                |
+---------------------------------------------------------------------------------------------+-----------------------+---------------------------+----------------------+
```

That's a huge improvement! Unfortunately, still not nearly as good as `array_unique`. Is there any other way this can be done? Let me know if you have any questions or comments.