### PR TITLE
Suppress warnings in PHP 8.1

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -95,6 +95,7 @@ class Collection implements IteratorAggregate, \Serializable, CollectionInterfac
      * {@inheritdoc}
      * @throws InvalidReturnValue
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         if ($this->inputFactory) {
@@ -119,16 +120,7 @@ class Collection implements IteratorAggregate, \Serializable, CollectionInterfac
      */
     public function serialize()
     {
-        return serialize(
-            toArray(
-                map(
-                    $this->input,
-                    function ($value, $key) {
-                        return [$key, $value];
-                    }
-                )
-            )
-        );
+        return serialize($this->__serialize());
     }
 
     /**
@@ -136,6 +128,29 @@ class Collection implements IteratorAggregate, \Serializable, CollectionInterfac
      */
     public function unserialize($serialized)
     {
-        $this->input = dereferenceKeyValue(unserialize($serialized));
+        $this->__unserialize(unserialize($serialized));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __serialize()
+    {
+        return toArray(
+            map(
+                $this->input,
+                function ($value, $key) {
+                    return [$key, $value];
+                }
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __unserialize($serialized)
+    {
+        $this->input = dereferenceKeyValue($serialized);
     }
 }


### PR DESCRIPTION
Suppress warnings that occurred after PHP 8.1. Still backwards compatible with older PHP versions.

![image](https://user-images.githubusercontent.com/1544220/154937215-1aef32a3-e0f2-4584-9a79-ecdabb072518.png)

